### PR TITLE
Fix waypoint mismatch handling .fms(version 1100) files & add command for reloading fpln files

### DIFF
--- a/plugins/KLN90B/data/modules/Custom Module/KLN90_panel.lua
+++ b/plugins/KLN90B/data/modules/Custom Module/KLN90_panel.lua
@@ -8187,15 +8187,9 @@ function enterident(ident, types, name, character, prevnext, lat, lon) --enterid
     table2[1] = {}
     if name == 0 then
       table2[1]["ident"] = makelength(ident, 5, 0)
-      table2[1]['name1'] = "ZZZZZ"
     else
       table2[1]["name1"] = makelength(ident, 11, 0)
-      table2[1]['ident'] = "ZZZZZ"
     end
-    table2[1]['lat'] = lat
-    table2[1]['lon'] = lon
-    table2[1]['types'] = types
-    length2 = 1
   end
   table2["length"] = length2
   table2["num"] = table2[1]["num"]


### PR DESCRIPTION
KLN90B was not handling the latest format of .fms files, sometimes mistaking different waypoints with same name due to wrong detection of latitudes and longitudes.
This was because v11 format files have one more column than v3 format files, between identifier and altitude which indicates whether the waypoint is in any airway, or is a dep/arr airport, or is just a direct route.

Also, since KLN90B only loads .fms files when loaded, I added a command for reloading .fms files - custom/KLN90B/reload_fpl


Edit at 1/7 1458z: sorry about the confusion, the last part of code change in enterident() was not a separate problem from waypoint mismatch but was associated with and caused by the mismatch, therefore being unnecessary. 