### PR TITLE
Disable LuaJIT on Linux and macOS

### DIFF
--- a/plugins/sasl/data/modules/main.lua
+++ b/plugins/sasl/data/modules/main.lua
@@ -2,6 +2,11 @@ print("This is the Tu154B-2 for XP12")
 size = { 4096, 4096 }
 print("Lua version is", _VERSION)
 
+if jit and jit.os ~= "Windows" then
+	jit.off()
+	jit.flush()
+	print("LuaJIT disabled")
+end
 
 sasl.options.set3DRendering(true)
 sasl.options.setAircraftPanelRendering(true)


### PR DESCRIPTION
This disables SASL's LuaJIT for Linux and macOS. LuaJIT almost always has a negative performance impact on Linux and macOS.