### PR TITLE
Prevent KLN90B .fms file refresh command from modifying FPL 0

### DIFF
--- a/plugins/KLN90B/data/modules/Custom Module/KLN90_panel.lua
+++ b/plugins/KLN90B/data/modules/Custom Module/KLN90_panel.lua
@@ -8556,8 +8556,8 @@ end
 
 --here we read the FPlans
 function readFpl(phase)
-if phase ~= 2 then return end
-local num1 = 0
+if phase ~= 2 and phase ~= 3 then return end
+local num1 = 3 - phase -- phase being 2 means command trigger, which prevents FPL 0 from changing / phase being 3 means trigger during KLN SASL init, thus loading FPL 0 as well 
 while num1 <= 25 do
 FPlan[num1] = {}
 FPlan[num1]["length"] = 0
@@ -8657,7 +8657,7 @@ num1 = num1 + 1
 end
 return false
 end
-readFpl(2)
+readFpl(3)
 sasl.registerCommandHandler(sasl.createCommand("custom/KLN90/reload_fpl", "Reload all flight plan(.fms) files"), 0, readFpl)
 
 


### PR DESCRIPTION
in case the command `custom/KLN90/reload_fpl` is triggered unintentionally, (like the hotkey or hardware button was mispressed), now this commands doesn't re-load FPL 0, which is most likely different from what is in the X-Plane 12/Output/FMS plans/KLN 90B/0.fms

I do know it's a trivial fix, but when we can do this without any cost, why not?